### PR TITLE
Change package name, version name, app constants and resource dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This repository contains a collection of build scripts examples for the [App Cen
 
 ### Xamarin
 - [Run NUnit based tests](xamarin/nunit-test/)
+- [Change package name](xamarin/package-name)
+- [Change version name](xamarin/version-name)
+- [Change app constants](xamarin/app-constants)
+- [Change resource dictionary](xamarin/resource-dictionary)
 
 # Contributing
 

--- a/xamarin/app-constants/appcenter-pre-build.sh
+++ b/xamarin/app-constants/appcenter-pre-build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# For Xamarin, change some constants located in some class of the app.
+# In this sample, suppose we have an AppConstant.cs class in shared folder with follow content:
+#
+# namespace Core
+# {
+#     public class AppConstant
+#     {
+#         public const string ApiUrl = "https://production.com/api";
+#     }
+# }
+# 
+# Suppose in our project exists two branches: master and develop. 
+# We can release app for production API in master branch and app for test API in develop branch. 
+# We just need configure this behaviour with environment variable in each branch :)
+# 
+# The same thing can be perform with any class of the app.
+#
+# AN IMPORTANT THING: FOR THIS SAMPLE YOU NEED DECLARE API_URL ENVIRONMENT VARIABLE IN APP CENTER BUILD CONFIGURATION.
+
+if [ ! -n "$API_URL" ]
+then
+    echo "You need define the API_URL variable in App Center"
+    exit
+fi
+
+APP_CONSTANT_FILE=$APPCENTER_SOURCE_DIRECTORY/Core/AppConstant.cs
+
+if [ -e "$APP_CONSTANT_FILE" ]
+then
+    echo "Updating ApiUrl to $API_URL in AppConstant.cs"
+    sed -i '' 's#ApiUrl = "[a-z:./]*"#ApiUrl = "'$API_URL'"#' $APP_CONSTANT_FILE
+
+    echo "File content:"
+    cat $APP_CONSTANT_FILE
+fi
+

--- a/xamarin/package-name/appcenter-pre-build.sh
+++ b/xamarin/package-name/appcenter-pre-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# For Xamarin Android or iOS, change the package name located in AndroidManifest.xml and Info.plist. 
+# AN IMPORTANT THING: YOU NEED DECLARE PACKAGE_NAME ENVIRONMENT VARIABLE IN APP CENTER BUILD CONFIGURATION.
+
+if [ ! -n "$PACKAGE_NAME" ]
+then
+    echo "You need define the PACKAGE_NAME variable in App Center"
+    exit
+fi
+
+ANDROID_MANIFEST_FILE=$APPCENTER_SOURCE_DIRECTORY/Droid/Properties/AndroidManifest.xml
+INFO_PLIST_FILE=$APPCENTER_SOURCE_DIRECTORY/iOS/Info.plist
+
+if [ -e "$ANDROID_MANIFEST_FILE" ]
+then
+    echo "Updating package name to $PACKAGE_NAME in AndroidManifest.xml"
+    sed -i '' 's/package="[a-z.]*"/package="'$PACKAGE_NAME'"/' $ANDROID_MANIFEST_FILE
+
+    echo "File content:"
+    cat $ANDROID_MANIFEST_FILE
+fi
+
+
+if [ -e "$INFO_PLIST_FILE" ]
+then
+    echo "Updating package name to $PACKAGE_NAME in Info.plist"
+    plutil -replace CFBundleIdentifier -string $PACKAGE_NAME $INFO_PLIST_FILE
+
+    echo "File content:"
+    cat $INFO_PLIST_FILE
+fi
+

--- a/xamarin/resource-dictionary/appcenter-pre-build.sh
+++ b/xamarin/resource-dictionary/appcenter-pre-build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# For Xamarin, change some resource dictionary value located in App.xaml. 
+#
+# Sample of App.xaml file:
+#
+# <?xml version="1.0" encoding="utf-8"?>
+# <Application xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Core.App">
+# 	<Application.Resources>
+#         <ResourceDictionary>
+#             <Color x:Key="MainColor">#00FF00</Color>
+#         </ResourceDictionary>
+# 	</Application.Resources>
+# </Application>
+#
+# In this sample, we change MainColor value in build time.
+# AN IMPORTANT THING: YOU NEED DECLARE MAIN_COLOR ENVIRONMENT VARIABLE IN APP CENTER BUILD CONFIGURATION.
+#
+
+if [ ! -n "$MAIN_COLOR" ]
+then
+    echo "You need define the MAIN_COLOR variable in App Center"
+    exit
+fi
+
+APP_FILE=$APPCENTER_SOURCE_DIRECTORY/Core/App.xaml
+
+if [ -e "$APP_FILE" ]
+then
+    echo "Updating main color to $MAIN_COLOR in App.xaml"
+    sed -i '' 's/"MainColor">[a-zA-Z0-9#]*</"MainColor">'$MAIN_COLOR'</' $APP_FILE
+
+    echo "File content:"
+    cat $APP_FILE
+fi
+

--- a/xamarin/version-name/appcenter-pre-build.sh
+++ b/xamarin/version-name/appcenter-pre-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# For Xamarin Android or iOS, change the version name located in AndroidManifest.xml and Info.plist. 
+# AN IMPORTANT THING: YOU NEED DECLARE VERSION_NAME ENVIRONMENT VARIABLE IN APP CENTER BUILD CONFIGURATION.
+
+if [ ! -n "$VERSION_NAME" ]
+then
+    echo "You need define the VERSION_NAME variable in App Center"
+    exit
+fi
+
+ANDROID_MANIFEST_FILE=$APPCENTER_SOURCE_DIRECTORY/Droid/Properties/AndroidManifest.xml
+INFO_PLIST_FILE=$APPCENTER_SOURCE_DIRECTORY/iOS/Info.plist
+
+if [ -e "$ANDROID_MANIFEST_FILE" ]
+then
+    echo "Updating version name to $VERSION_NAME in AndroidManifest.xml"
+    sed -i '' 's/versionName="[0-9.]*"/versionName="'$VERSION_NAME'"/' $ANDROID_MANIFEST_FILE
+
+    echo "File content:"
+    cat $ANDROID_MANIFEST_FILE
+fi
+
+
+if [ -e "$INFO_PLIST_FILE" ]
+then
+    echo "Updating version name to $VERSION_NAME in Info.plist"
+    plutil -replace CFBundleShortVersionString -string $VERSION_NAME $INFO_PLIST_FILE
+
+    echo "File content:"
+    cat $INFO_PLIST_FILE
+fi
+


### PR DESCRIPTION
This scripts perform some configuration in Xamarin projects, such as change package name, version name, app constants and resource dictionary values.

The scripts are totally dynamic because uses App Center environment variables.

![appcenter-environment-variables](https://user-images.githubusercontent.com/519642/36705762-8f69fd8c-1b45-11e8-96d1-6a500c7df6af.png)
