### PR TITLE
Update appcenter-post-build.sh

### DIFF
--- a/react-native/detox/appcenter-post-build.sh
+++ b/react-native/detox/appcenter-post-build.sh
@@ -11,6 +11,8 @@
 #    from source instead.
 #
 # 3) Your Node version and Detox build command might be slightly different.
+#
+# 4) If you're using yarn, make sure to use it instead of npm, to avoid clashes in dependencies 
 
 
 echo "Installing applesimutils..."
@@ -18,7 +20,7 @@ mkdir simutils
 cd simutils
 curl https://raw.githubusercontent.com/wix/homebrew-brew/master/AppleSimulatorUtils-0.5.22.tar.gz -o applesimutils.tar.gz
 tar xzvf applesimutils.tar.gz
-sh buildForBrew.sh 
+sh buildForBrew.sh .
 cd ..
 export PATH=$PATH:./simutils/build/Build/Products/Release
 


### PR DESCRIPTION
When taking the script as-is, the `sh buildForBrew.sh` step fails with `cp: /bin/applesimutils: Operation not permitted`.

[this](https://github.com/wix/AppleSimulatorUtils/blob/master/buildForBrew.sh) is the script that is being executed

on the first line you see `targetDir="$1"`, ie. it needs a parameter but it is called without a parameter so `targetDir` value is empty.

the last command in the buildForBrew script is `cp build/Build/Products/Release/applesimutils "$targetDir"/bin`. Because $targetDir is empty, it ends up being `cp build/Build/Products/Release/applesimutils /bin` hence I get `cp: /bin/applesimutils: Operation not permitted`