### PR TITLE
Fix NUnit script for Xamarin

### DIFF
--- a/xamarin/nunit-test/appcenter-post-build.sh
+++ b/xamarin/nunit-test/appcenter-post-build.sh
@@ -21,7 +21,7 @@ cat $pathOfTestResults
 echo
 
 #look for a failing test
-grep -q 'success="False"' $pathOfTestResults
+grep -q 'result="Failed"' $pathOfTestResults
 
 if [[ $? -eq 0 ]]
 then 

--- a/xamarin/nunit-test/appcenter-post-build.sh
+++ b/xamarin/nunit-test/appcenter-post-build.sh
@@ -13,7 +13,7 @@ echo "Compiled projects to run NUnit tests:"
 find $APPCENTER_SOURCE_DIRECTORY -regex '.*bin.*Test.*\.dll' -exec echo {} \;
 echo
 echo "Running NUnit tests:"
-find $APPCENTER_SOURCE_DIRECTORY -regex '.*bin.*Test.*\.dll' -exec nunit3-console {} \;
+find $APPCENTER_SOURCE_DIRECTORY -regex '.*bin.*Test.*\.dll' -exec nunit3-console {} +
 echo
 echo "NUnit tests result:"
 pathOfTestResults=$(find $APPCENTER_SOURCE_DIRECTORY -name 'TestResult.xml')


### PR DESCRIPTION
- Nunit will have `result="Failed"` in the results XML if anything goes wrong during running the test

- `nunit3-console {} \;` will run nunit X number of times with one dll param and will write actual test result into one XML file, overwriting the previous one. `nunit3-console {} +` should concat dll file paths into one list of params and will run nunit once (eg. `nunit3-console Test1.dll Test2.dll` ), which will generate one XML with all the test results