### PR TITLE
Change Regex to match Common Package Names

### DIFF
--- a/xamarin/package-name/appcenter-pre-build.sh
+++ b/xamarin/package-name/appcenter-pre-build.sh
@@ -15,7 +15,7 @@ INFO_PLIST_FILE=$APPCENTER_SOURCE_DIRECTORY/iOS/Info.plist
 if [ -e "$ANDROID_MANIFEST_FILE" ]
 then
     echo "Updating package name to $PACKAGE_NAME in AndroidManifest.xml"
-    sed -i '' 's/package="[a-z.]*"/package="'$PACKAGE_NAME'"/' $ANDROID_MANIFEST_FILE
+    sed -i '' 's/package="[^"]*"/package="'$PACKAGE_NAME'"/' $ANDROID_MANIFEST_FILE
 
     echo "File content:"
     cat $ANDROID_MANIFEST_FILE


### PR DESCRIPTION
Most package names are formatted like so `com.domain.app` the regex in this example is very restrictive and would only accept `com.` It makes more sense to accept anything between the first `"` and second `"`.