### PR TITLE
Adding iOS script to use the same CocoaPods version as the Podfile.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains a collection of build scripts examples for the [App Cen
 
 ### iOS
 - [Use App Center pre-release SDK](ios/appcenter-beta-sdk/)
+- [Use the same CocoaPods version as the Pod lockfile](ios/match-cocoapods-version-to-lockfile/appcenter-post-clone.sh)
 
 ### React Native
 - [Run Detox](react-native/detox/)

--- a/ios/match-cocoapods-version-to-lockfile/appcenter-post-clone.sh
+++ b/ios/match-cocoapods-version-to-lockfile/appcenter-post-clone.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Uninstalling all CocoaPods versions"
+sudo gem uninstall cocoapods --all --executables
+
+COCOAPODS_VER=`sed -n -e 's/^COCOAPODS: \([0-9.]*\)/\1/p' Podfile.lock`
+
+echo "Installing CocoaPods version $COCOAPODS_VER"
+sudo gem install cocoapods -v $COCOAPODS_VER


### PR DESCRIPTION
This iOS script will install the same CocoaPods version that is defined in the `Podfile.lock` file.