### PR TITLE
Specify stable flutter release channel

### DIFF
--- a/flutter/android-build/appcenter-post-clone.sh
+++ b/flutter/android-build/appcenter-post-clone.sh
@@ -12,6 +12,7 @@ cd ..
 git clone -b dev https://github.com/flutter/flutter.git
 export PATH=`pwd`/flutter/bin:$PATH
 
+flutter channel stable
 flutter doctor
 
 echo "Installed flutter to `pwd`/flutter"

--- a/flutter/ios-build/appcenter-post-clone.sh
+++ b/flutter/ios-build/appcenter-post-clone.sh
@@ -10,6 +10,7 @@ cd ..
 git clone -b dev https://github.com/flutter/flutter.git
 export PATH=`pwd`/flutter/bin:$PATH
 
+flutter channel stable
 flutter doctor
 
 echo "Installed flutter to `pwd`/flutter"


### PR DESCRIPTION
Without this command, builds will use the `dev` flutter [release channel](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels) by default. 